### PR TITLE
Disable compiler flag that interprets warnings as errors

### DIFF
--- a/Makefile.tarball
+++ b/Makefile.tarball
@@ -10,8 +10,10 @@ mercury_planner: $(SOURCE_DIR)/unpacked
 	echo "HELLO: " $(SOURCE_DIR)
 	tar -xvf $(SOURCE_DIR)/seq-sat-mercury.tar.gz -C $(SOURCE_DIR)
 	echo 'Compiling mercury planner preprocess (1/2) ...'
+	sed -i 's/-Werror/ \ /g' $(SOURCE_DIR)/seq-sat-mercury/src/preprocess/Makefile
 	make -C $(SOURCE_DIR)/seq-sat-mercury/src/preprocess
 	echo 'Compiling mercury planner search (2/2) ...'
+	sed -i 's/-Werror/ \ /g' $(SOURCE_DIR)/seq-sat-mercury/src/search/Makefile
 	make -C $(SOURCE_DIR)/seq-sat-mercury/src/search
 
 clean:


### PR DESCRIPTION
Two Makefiles in the tarball are presently interpreting all the compiler warnings as errors. This causes build errors on systems with gcc-6 and above as these compilers also warn about incorrect indentations.

Therefore, with this pull request, we disable the `-Werror` compiler flag in the Makefiles. This shouldnt have any problems with the current builds and should fix problems with all future gcc versions. This is also required for building with ROS-Melodic.

## Changelog
<!-- Add a list of bullets with the summary of your changes -->
<!-- Try to use infinitives: Fix, Remove, Rename, Add, Refactor -->

* Updated the Makefile.tarball to replace the `-Werror` in two Makefiles with a whitespace.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
